### PR TITLE
Removes workaround for SDK bug #294 (fixed in release 0.5.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 13.2'
-gem 'temporalio', '~> 0.4'
+gem 'temporalio', '~> 0.5'
 
 group :test do
   gem 'minitest'

--- a/shared.rb
+++ b/shared.rb
@@ -6,25 +6,13 @@ require 'temporalio/error'
 module MoneyTransfer
   TASK_QUEUE_NAME = 'money-transfer'
 
-  # NOTE: The two custom error types that follow are defined in an
-  # unusual way, by subclassing ApplicationError and overriding its
-  # non_retryable method. This is a workaround for an SDK bug (#294).
-  # Typically, you would subclass StandardError and specify the type
-  # as non-retryable in the RetryPolicy, but this approach does not
-  # work due to the bug. We'll update the code once the bug is fixed.
-  class InsufficientFundsError < Temporalio::Error::ApplicationError
-    def non_retryable
-      true
-    end
-  end
+  # InsufficientFundsError is raised when the source account
+  # balance is too low to successfully complete the withdrawal.
+  class InsufficientFundsError < StandardError; end
 
   # InvalidAccountError is raised when the account identifier
   # for the transaction does not reference an active account.
-  class InvalidAccountError < Temporalio::Error::ApplicationError
-    def non_retryable
-      true
-    end
-  end
+  class InvalidAccountError < StandardError; end
 
   # @@@SNIPSTART money-transfer-project-template-ruby-shared-transfer-details
   # TransferDetails is the input to MoneyTransferWorkflow (and its Activities).

--- a/shared.rb
+++ b/shared.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json/add/struct'
-require 'temporalio/error'
 
 module MoneyTransfer
   TASK_QUEUE_NAME = 'money-transfer'


### PR DESCRIPTION
## What was changed

I removed the [workaround](https://github.com/temporalio/money-transfer-project-template-ruby/commit/227dfae9d1d3beaca85a545b36a952c7fa126078) that I had added as a result of Ruby SDK bug [#294](https://github.com/temporalio/sdk-ruby/issues/294). I also upgraded the dependencies to use SDK version 0.5.0, which was released a few hours ago.

## Why?
<!-- Tell your future self why have you made these changes -->
Version 0.5.0 of the SDK fixes the problem with designating certain error types as non-retryable in the Retry Policy, so the workaround is no longer necessary. 