### PR TITLE
Config client from profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'rake', '~> 13.2'
-gem 'temporalio', '~> 1.0.0'
+gem 'rake'
+gem 'temporalio'
 
 group :test do
   gem 'minitest'

--- a/shared.rb
+++ b/shared.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'json/add/struct'
+require 'temporalio/env_config'
+require 'temporalio/client'
 
 module MoneyTransfer
   TASK_QUEUE_NAME = 'money-transfer'
@@ -23,4 +26,21 @@ module MoneyTransfer
     end
   end
   # @@@SNIPEND
+
+  # Create the Temporal Client that connects to the Temporal Service.
+  # By default, it will connect to one running locally, on the standard
+  # port, and use the default Namespace. You can override this by setting
+  # the TEMPORAL_PROFILE environment variable to the name of a specific
+  # profile that you've set up using the Temporal CLI.
+  def self.create_client
+    profile = ENV['TEMPORAL_PROFILE']
+    args, kwargs = Temporalio::EnvConfig::ClientConfig.load_client_connect_options(
+      profile: profile
+    )
+
+    args[0] ||= 'localhost:7233'
+    args[1] ||= 'default'
+
+    Temporalio::Client.connect(*args, **kwargs)
+  end
 end

--- a/starter.rb
+++ b/starter.rb
@@ -6,10 +6,9 @@ require_relative 'workflow'
 require 'securerandom'
 require 'temporalio/client'
 
-# Create the Temporal Client that the Worker will use to connect to the
-# Temporal Service (in this case, it will connect to one running locally,
-# on the standard port, and use the default namespace)
-client = Temporalio::Client.connect('localhost:7233', 'default')
+# Create the Temporal Client that the Worker uses to communicate with
+# the Temporal Service
+client = MoneyTransfer.create_client
 
 # Default values for the payment details (can override via positional commandline parameters)
 details = MoneyTransfer::TransferDetails.new('A1001', 'B2002', 100, SecureRandom.uuid)
@@ -39,4 +38,3 @@ rescue Temporalio::Error::RPCError
   retry
 end
 # @@@SNIPEND
-

--- a/worker.rb
+++ b/worker.rb
@@ -4,17 +4,11 @@
 require_relative 'activities'
 require_relative 'shared'
 require_relative 'workflow'
-require 'logger'
 require 'temporalio/client'
 require 'temporalio/worker'
 
-# Create a Temporal Client that connects to a local Temporal Service, uses
-# a Namespace called 'default', and displays log messages to standard output
-client = Temporalio::Client.connect(
-  'localhost:7233',
-  'default',
-  logger: Logger.new($stdout, level: Logger::INFO)
-)
+# Create a Temporal Client that connects to the Temporal Service
+client = MoneyTransfer::create_client
 
 # Create a Worker that polls the specified Task Queue and can 
 # fulfill requests for the specified Workflow and Activities


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
DO NOT MERGE.

I have created this draft PR to support review and sharing this code. However, I do not intend for this code to become part of the `main` branch right now. 

## What was changed
I added code to configure the Temporal Client from a configuration file that defines a named profile, which specifies the frontend address of the Temporal Service, the Namespace, and details related to the desired authentication method. The configuration file is loaded from its default location, while the profile name is specified through an environment variable (`TEMPORAL_PROFILE`). I also updated the Clients created by the Worker and Starter code to use the Client Options returned by this code.


## Why?
<!-- Tell your future self why have you made these changes -->
Currently, the clients used in this tutorial have no explicit configuration and rely solely on the default options. Imagine that someone new to Temporal application development signed up for Temporal Cloud on their own and now wants to run this intro-level money transfer tutorial. Getting it to work with Temporal Cloud requires making changes to the Client configuration, but this user won't know what to change. Note that this scenario I've described isn't limited to Temporal Cloud. Someone using a non-default Namespace name or a non-local Temporal Service would have the same problem.

Having the clients configure themselves based on the presence of environment variables eliminates the need to hardcode the frontend address, Namespace name, or authentication details. It helps the user understand that the application logic remains unchanged when migrating from the Temporal Service used for development on their laptop to a production Temporal Service (or vice versa). Finally, this makes it easier for users to run this example locally, on a remote self-hosted cluster, or on Temporal Cloud. 

This updated takes advantage of the pre-release support for profile-based configuration in the Ruby SDK

NOTE: I have updated the code but not the prose in the tutorial, pending further discussion with the Education team. I plan to make similar changes to the other money-transfer repositories, but if it turns out that is not viable, then I will probably need to fork these repos and tutorials to support the onboarding path for new cloud users.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

This does not close an issue, but enables further progress of EDU-3801. That issue would be closed only after all similar tutorials have been updated.

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I tested this by first creating a profile named `cloud` using the Temporal CLI (note that these values are similar to but not identical to the ones I actually set):

```
$ temporal --profile cloud config set --prop address --value "us-east-1.aws.api.temporal.io:7233"
$ temporal --profile cloud config set --prop namespace --value "example.c9ef8"
$ temporal --profile cloud config set --prop api_key --value "abc123.actual.value.redacted.xyz789"
```

According to the output from this command, the config file was created at `$HOME/Library/Application Support/temporalio/temporal.toml`.

I then set an environment variable:

```
export TEMPORAL_PROFILE=cloud
```

I started the Worker by running `bundle exec ruby worker.rb`. Finally, I opened a new terminal tab, set the same environment variable as above, and started the Workflow by running `bundle exec ruby starter.rb`. I verified in the Temporal Cloud Web UI that the Workflow Execution ran and completed successfully. 

I also set up a profile for mTLS authentication with Temporal Cloud and successfully ran it with the implementation provided here.

3. Any docs updates needed?

The tutorial prose will require a small update to describe the changes.